### PR TITLE
Close the dropdown menu when "Sign up" is clicked

### DIFF
--- a/app/js/app/controllers/LoginControllers.js
+++ b/app/js/app/controllers/LoginControllers.js
@@ -70,6 +70,7 @@ export const PageController = ['$scope', 'auth', 'api', 'persistence', '$statePa
 
 	$scope.signUpFunction = function() {
 		persistence.save('afterAuth', $scope.target || "");
+		$("#mobile-login-form").ruDropDownHide(this);
 		$scope.$root.user.email = $scope.loginUser.email;
 		$scope.$root.user.password = $scope.loginUser.password;
 		return $scope.user;


### PR DESCRIPTION
Previously clicking signup would only redirect you to the register
page and the login dropdown would remain open.
On small screens the dropdown could cover most of the page so it
would not be obvious you have moved to the register page.

Now the dropdown is hidden when the sign up button is clicked.

---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Removed Unnecessary Logs/System.Outs/Comments/TODOs
- [ ] Added enough Logging to monitor expected behaviour change
- [ ] Security - XSS/Injection - All user input validated or encoded before being used in page or URL
- [ ] Security - Data Exposure - PII is not sent in URL or query params
- [ ] Security - Access Control - Suitable authorisation added to new pages
- [ ] Security - New dependency - Searched for any known vulnerabilities
- [ ] Security - New dependency - Signed up team to mailing list
- [ ] Security - New dependency - Added to dependency list
- [ ] Updated Release Procedure & Documentation
- [ ] Peer-Reviewed