### PR TITLE
Fix for event bookings stats bug

### DIFF
--- a/app/js/app/controllers/AdminPageControllers.js
+++ b/app/js/app/controllers/AdminPageControllers.js
@@ -77,9 +77,7 @@ export const AdminStatsSummaryController = ["$scope", "api", function($scope, ap
 
         $scope.setLoading(false)
     });
-    api.eventBookings.getAllBookings({
-        "count_only": true
-    }).$promise.then(function(result) {
+    api.eventBookings.getCountForAllBookings().$promise.then(function(result) {
         $scope.eventBookingsCount = result.count;
     })
 }];

--- a/app/js/app/services/Api.js
+++ b/app/js/app/services/Api.js
@@ -343,8 +343,8 @@ define([], function() {
         this.eventMapData = $resource(urlPrefix + "/events/map_data?start_index=:startIndex&limit=:limit&show_active_only=:showActiveOnly");
 
         this.eventBookings = $resource(urlPrefix + "/events/:eventId/bookings/:userId", {eventId: '@eventId', userId: '@userId'}, {
-            'getAllBookings' : {
-                url: urlPrefix + "/events/bookings",
+            'getCountForAllBookings' : {
+                url: urlPrefix + "/events/bookings/count",
                 method: 'GET', 
             },
             'getBookings' : {


### PR DESCRIPTION
Change get event bookings endpoint to be a new count endpoint - that doesn't explode.

Requires API PR https://github.com/isaacphysics/isaac-api/pull/245 to be merged first:


---

**Pull Request Check List**
- [ ] Unit Tests & Regression Tests Added (Optional)
- [ ] Peer-Reviewed