### PR TITLE
Update name of streak data in user progress now weekly streaks exist

### DIFF
--- a/app/js/app/controllers/MyProgressPageControllers.js
+++ b/app/js/app/controllers/MyProgressPageControllers.js
@@ -88,15 +88,15 @@ export const PageController = ['$rootScope','$scope', 'auth', 'api', 'tags', '$s
         }
 
         // --- STREAK PROGRESS --- //
-        if ($scope.progress.userSnapshot.streakRecord) {
+        if ($scope.progress.userSnapshot.dailyStreakRecord) {
             let currentProgressValue = $('#current-streak-progress-bar');
             let radius = 40;
             let circumference = 2 * Math.PI * radius;
             let currentDashOffset = circumference;
 
-            if ($scope.progress.userSnapshot.streakRecord.currentActivity <= 3) {
-                currentDashOffset = circumference * (1 - ($scope.progress.userSnapshot.streakRecord.currentActivity/3));
-            } else if ($scope.progress.userSnapshot.streakRecord.currentActivity > 3) {
+            if ($scope.progress.userSnapshot.dailyStreakRecord.currentActivity <= 3) {
+                currentDashOffset = circumference * (1 - ($scope.progress.userSnapshot.dailyStreakRecord.currentActivity/3));
+            } else if ($scope.progress.userSnapshot.dailyStreakRecord.currentActivity > 3) {
                 currentDashOffset = 0;
             }
 

--- a/app/partials/states/my_progress.html
+++ b/app/partials/states/my_progress.html
@@ -56,12 +56,12 @@
                                     fill="none"></circle>
                         </svg>
                         <div class="streak-value-progress">
-                            {{ progress.userSnapshot.streakRecord.currentStreak || 0 }}
+                            {{ progress.userSnapshot.dailyStreakRecord.currentStreak || 0 }}
                         </div>
                     </div>
                     <div style="text-align: center;">
-                        Longest streak: {{ progress.userSnapshot.streakRecord.largestStreak || 0 }}
-                        day<span ng-if="progress.userSnapshot.streakRecord.largestStreak != 1">s</span>
+                        Longest streak: {{ progress.userSnapshot.dailyStreakRecord.largestStreak || 0 }}
+                        day<span ng-if="progress.userSnapshot.dailyStreakRecord.largestStreak != 1">s</span>
                         <span
                             style="cursor: pointer;"
                             data-ot-escape-content="false"


### PR DESCRIPTION
Note that this doesn't change the name inside WebSockets, since they still only show daily streak information for speed purposes.

Requires https://github.com/isaacphysics/isaac-api/pull/250 to be merged first!